### PR TITLE
AppleBacklightFixup is not needed anymore (included in WhateverGreen)

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -97,7 +97,6 @@ download os-x-eapd-codec-commander RehabMan-CodecCommander
 download os-x-brcmpatchram RehabMan-BrcmPatchRAM
 download os-x-acpi-poller RehabMan-Poller
 download os-x-usb-inject-all RehabMan-USBInjectAll
-download applebacklightfixup RehabMan-BacklightFixup
 download_latest_notbitbucket "https://github.com" "https://github.com/acidanthera/Lilu/releases" "RELEASE" "nbb_acidanthera-Lilu.zip"
 download_latest_notbitbucket "https://github.com" "https://github.com/acidanthera/VirtualSMC/releases" "RELEASE" "nbb_acidanthera-VirtualSMC.zip"
 download_latest_notbitbucket "https://github.com" "https://github.com/acidanthera/AppleALC/releases" "RELEASE" "nbb_acidanthera-AppleALC.zip"
@@ -126,8 +125,8 @@ download_raw https://raw.githubusercontent.com/black-dragon74/OSX-Debug/master/I
 cd ..
 
 NECESSARYLEKEXTS="BrcmPatchRAM2|BrcmFirmwareRepo|CodecCommander"
-LEKEXTS="ACPIBatteryManager|ACPIPoller|AppleALC|AppleBacklightFixup|AsusSMC|AirportBrcmFixup|BT4LEContiunityFixup|FakePCIID.kext|FakePCIID_Broadcom_WiFi|WhateverGreen|Lilu|LiluFriend|NullEthernet.kext|USBInjectAll|VirtualSMC|SMCProcessor.kext|VoodooI2C.kext|VoodooI2CHID.kext|VoodooPS2Controller"
-CLOVERKEXTS="ACPIBatteryManager|ACPIPoller|AppleALC|AppleBacklightFixup|AsusSMC|AirportBrcmFixup|BT4LEContiunityFixup|FakePCIID.kext|FakePCIID_Broadcom_WiFi|WhateverGreen|Lilu|LiluFriend|NullEthernet.kext|USBInjectAll|VirtualSMC|SMCProcessor.kext|VoodooI2C.kext|VoodooI2CHID.kext|VoodooPS2Controller"
+LEKEXTS="ACPIBatteryManager|ACPIPoller|AppleALC|AsusSMC|AirportBrcmFixup|BT4LEContiunityFixup|FakePCIID.kext|FakePCIID_Broadcom_WiFi|WhateverGreen|Lilu|LiluFriend|NullEthernet.kext|USBInjectAll|VirtualSMC|SMCProcessor.kext|VoodooI2C.kext|VoodooI2CHID.kext|VoodooPS2Controller"
+CLOVERKEXTS="ACPIBatteryManager|ACPIPoller|AppleALC|AsusSMC|AirportBrcmFixup|BT4LEContiunityFixup|FakePCIID.kext|FakePCIID_Broadcom_WiFi|WhateverGreen|Lilu|LiluFriend|NullEthernet.kext|USBInjectAll|VirtualSMC|SMCProcessor.kext|VoodooI2C.kext|VoodooI2CHID.kext|VoodooPS2Controller"
 
 function check_directory
 {


### PR DESCRIPTION
**Closes issue** #


**What has been done in this PR ?**
